### PR TITLE
fix(release): android workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,10 @@ jobs:
           flutter-version: ${{env.FLUTTER_VERSION}}
 
       - name: Deps
-        run: flutter pub get
+        id: setup
+        run: |
+          flutter pub get
+          echo ::set-output name=tag::${GITHUB_REF##*/}
 
       - name: Build
         run: |


### PR DESCRIPTION
Was missing the name tag for android workflow. Changed so android build will be created on release page.