### PR TITLE
feat(tutorial): Add a tutorial screen for instructions how to use app

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ may be troublesome, although implemented).
 1. Open _Controller Settings_
 2. Click _Alternate Input Sources_
 3. Check _Enable_
-4. Fill in your phone's IP Address and port number `26760`.
-5. Select _Emulated Wii Remote_ as "Wii Remote 1" and click **Configure**.
-6. While the application is open on your phone, "DSUClient/0/DualShock 3" (your phone) should be listed as possible input device, select it as input device.
+4. Click _Add_
+5. Fill in your phone's IP Address (find in app settings), port number `26760`, and give it a description.
+6. Select _Emulated Wii Remote_ as "Wii Remote 1" and click **Configure**.
+7. While the application is open on your phone, "DSUClient/0/\[your_description\]" (your phone) should be listed as possible input device, select it as input device.
 
    <img src="controller-configuration.png" alt="Screenshot of controller configuration" width="500"/>
 
-7. You can now either map the buttons manually or use the `WiiMoteDSU.ini` profile file in this repository:
+8. You can now either map the buttons manually or use the `WiiMoteDSU.ini` profile file in this repository:
    1. If using the profile from this repository place it within the Config folder of Dolphin:
       - Windows: `(Documents/Dolphin Emulator/)Config/Profiles/Wiimote/WiiMoteDSU.ini`
       - Mac OS: `/Users/username/Library/Application Support/Dolphin/Config/Profiles/Wiimote/WiiMoteDSU.ini`

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -9,6 +9,8 @@ PODS:
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
+  - url_launcher_ios (0.0.1):
+    - Flutter
   - wakelock_plus (0.0.1):
     - Flutter
 
@@ -18,6 +20,7 @@ DEPENDENCIES:
   - network_info_plus (from `.symlinks/plugins/network_info_plus/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
   - wakelock_plus (from `.symlinks/plugins/wakelock_plus/ios`)
 
 EXTERNAL SOURCES:
@@ -31,6 +34,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info_plus/ios"
   shared_preferences_foundation:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+  url_launcher_ios:
+    :path: ".symlinks/plugins/url_launcher_ios/ios"
   wakelock_plus:
     :path: ".symlinks/plugins/wakelock_plus/ios"
 
@@ -40,6 +45,7 @@ SPEC CHECKSUMS:
   network_info_plus: cf61925ab5205dce05a4f0895989afdb6aade5fc
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   wakelock_plus: e29112ab3ef0b318e58cfa5c32326458be66b556
 
 PODFILE CHECKSUM: 0dbd5a87e0ace00c9610d2037ac22083a01f861d

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,10 @@ import 'package:wiimote_dsu/models/gyro_settings.dart';
 import 'package:wiimote_dsu/server/server_isolate.dart';
 import 'package:wiimote_dsu/ui/screens/device_screen.dart';
 import 'package:wiimote_dsu/ui/screens/settings_screen.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial_screen.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
+
+const String _kTutorialCompletedKey = 'tutorial_completed';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,19 +26,28 @@ void main() async {
 
   final mainToIsolateStream = await ServerIsolate.init();
 
-  final dsuDevice =
-      Device(gyroSettings, accSettings, deviceSettings, mainToIsolateStream);
+  final dsuDevice = Device(
+    gyroSettings,
+    accSettings,
+    deviceSettings,
+    mainToIsolateStream,
+  );
   mainToIsolateStream.send(dsuDevice);
   dsuDevice.start();
 
   WakelockPlus.enable();
 
-  runApp(MultiProvider(providers: [
-    ChangeNotifierProvider<GyroSettings>.value(value: gyroSettings),
-    ChangeNotifierProvider<AccSettings>.value(value: accSettings),
-    ChangeNotifierProvider<DeviceSettings>.value(value: deviceSettings),
-    Provider<SendPort>.value(value: mainToIsolateStream),
-  ], child: WiiMoteDSUApp(prefs)));
+  runApp(
+    MultiProvider(
+      providers: [
+        ChangeNotifierProvider<GyroSettings>.value(value: gyroSettings),
+        ChangeNotifierProvider<AccSettings>.value(value: accSettings),
+        ChangeNotifierProvider<DeviceSettings>.value(value: deviceSettings),
+        Provider<SendPort>.value(value: mainToIsolateStream),
+      ],
+      child: WiiMoteDSUApp(prefs),
+    ),
+  );
 }
 
 class WiiMoteDSUApp extends StatelessWidget {
@@ -48,19 +60,54 @@ class WiiMoteDSUApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'WiiMoteDSU',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
-      home: MyHomePage(
-        title: 'WiiMoteDSU',
-        preferences: preferences,
-      ),
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: _TutorialGate(title: 'WiiMoteDSU', preferences: preferences),
     );
   }
 }
 
+class _TutorialGate extends StatefulWidget {
+  final SharedPreferences preferences;
+  final String title;
+
+  const _TutorialGate({required this.preferences, required this.title});
+
+  @override
+  State<_TutorialGate> createState() => _TutorialGateState();
+}
+
+class _TutorialGateState extends State<_TutorialGate> {
+  bool _showTutorial = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final completed = widget.preferences.getBool(_kTutorialCompletedKey);
+    _showTutorial = completed != true;
+  }
+
+  void _openHome(BuildContext context) {
+    widget.preferences.setBool(_kTutorialCompletedKey, true);
+    Navigator.of(context).pushReplacement(
+      MaterialPageRoute(
+        builder: (_) =>
+            MyHomePage(title: widget.title, preferences: widget.preferences),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_showTutorial) {
+      return TutorialScreen(onComplete: _openHome);
+    }
+    return MyHomePage(title: widget.title, preferences: widget.preferences);
+  }
+}
+
 class MyHomePage extends StatefulWidget {
-  MyHomePage({Key? key, required this.title, required this.preferences}) : super(key: key);
+  MyHomePage({Key? key, required this.title, required this.preferences})
+    : super(key: key);
 
   final String title;
   final SharedPreferences preferences;
@@ -78,17 +125,20 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return AnnotatedRegion<SystemUiOverlayStyle>(
-        value: SystemUiOverlayStyle.dark,
-        child: Scaffold(
-          backgroundColor: Colors.white,
-          body: Stack(children: <Widget>[
+      value: SystemUiOverlayStyle.dark,
+      child: Scaffold(
+        backgroundColor: Colors.white,
+        body: Stack(
+          children: <Widget>[
             DeviceScreen(),
             Positioned(
-                top: 30.0,
-                left: 2.0,
-                child: IconButton(
-                    icon: Icon(Icons.settings),
-                    onPressed: () => _openSettings(context))),
+              top: 30.0,
+              left: 2.0,
+              child: IconButton(
+                icon: Icon(Icons.settings),
+                onPressed: () => _openSettings(context),
+              ),
+            ),
             Positioned(
               top: 30.0,
               right: 2.0,
@@ -98,21 +148,28 @@ class _MyHomePageState extends State<MyHomePage> {
                     icon: Text(
                       "${settings.slot}",
                       style: TextStyle(
-                          fontWeight: FontWeight.bold, fontSize: 16.0),
+                        fontWeight: FontWeight.bold,
+                        fontSize: 16.0,
+                      ),
                     ),
                     onPressed: null,
                   );
                 },
               ),
-            )
-          ]),
-        ));
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   void _openSettings(BuildContext context) {
-    Navigator.of(context)
-        .push(MaterialPageRoute(builder: (BuildContext context) {
-      return SettingsScreen();
-    }));
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (BuildContext context) {
+          return SettingsScreen();
+        },
+      ),
+    );
   }
 }

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wiimote_dsu/models/acc_settings.dart';
 import 'package:wiimote_dsu/models/device_settings.dart';
 import 'package:wiimote_dsu/models/gyro_settings.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial_screen.dart';
 
 class SettingsScreen extends StatefulWidget {
   _SettingsScreen createState() => _SettingsScreen();
@@ -37,6 +38,19 @@ class _SettingsScreen extends State<SettingsScreen> {
                 Widget? child) {
           return ListView(
             children: [
+              ListTile(
+                title: Text('Show tutorial again'),
+                leading: Icon(Icons.school_outlined),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => TutorialScreen(
+                        onComplete: (context) => Navigator.of(context).pop(),
+                      ),
+                    ),
+                  );
+                },
+              ),
               ListTile(
                 title: Text('Slot'),
                 trailing: DropdownButton<int>(
@@ -173,7 +187,6 @@ class _SettingsScreen extends State<SettingsScreen> {
                       vertical: 10.0, horizontal: 10.0),
                   child: ElevatedButton(
                       style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.blueAccent,
                         shape: RoundedRectangleBorder(
                           borderRadius: BorderRadius.circular(18.0),
                         ),

--- a/lib/ui/screens/tutorial/tutorial_configure_page_content.dart
+++ b/lib/ui/screens/tutorial/tutorial_configure_page_content.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:network_info_plus/network_info_plus.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial/tutorial_slide.dart';
+
+/// Third tutorial page: Configure Dolphin summary + tap for detailed steps.
+class TutorialConfigurePageContent extends StatelessWidget {
+  final bool isActive;
+  final VoidCallback onShowDetails;
+  final TutorialSlide slide;
+
+  const TutorialConfigurePageContent({
+    super.key,
+    required this.isActive,
+    required this.onShowDetails,
+    required this.slide,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      opacity: isActive ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 280),
+      child: AnimatedSlide(
+        offset: isActive ? Offset.zero : const Offset(0, 0.08),
+        duration: const Duration(milliseconds: 280),
+        curve: Curves.easeOutCubic,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                slide.icon,
+                size: 72,
+                color: Theme.of(context).primaryColor,
+              ),
+              const SizedBox(height: 24),
+              Text(
+                slide.title,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                slide.body,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Colors.grey[700],
+                      height: 1.4,
+                    ),
+              ),
+              const SizedBox(height: 16),
+              FutureBuilder<String?>(
+                future: NetworkInfo().getWifiIP(),
+                builder: (context, snapshot) {
+                  if (snapshot.hasData && snapshot.data != null) {
+                    return Text(
+                      'Your IP: ${snapshot.data}',
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                            color: Theme.of(context).primaryColor,
+                          ),
+                    );
+                  }
+                  if (snapshot.connectionState == ConnectionState.waiting) {
+                    return Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Getting your IP…',
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: Colors.grey[700],
+                              ),
+                        ),
+                      ],
+                    );
+                  }
+                  return const SizedBox.shrink();
+                },
+              ),
+              const SizedBox(height: 32),
+              GestureDetector(
+                onTap: onShowDetails,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 16,
+                    horizontal: 20,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).primaryColor.withValues(alpha: 0.08),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(
+                      color: Theme.of(context).primaryColor.withValues(alpha: 0.3),
+                    ),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.list_alt,
+                        size: 28,
+                        color: Theme.of(context).primaryColor,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          'Tap for step-by-step instructions',
+                          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                color: Theme.of(context).primaryColor,
+                                fontWeight: FontWeight.w500,
+                              ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/tutorial/tutorial_detail_screen.dart
+++ b/lib/ui/screens/tutorial/tutorial_detail_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial/tutorial_steps_content.dart';
+
+/// Full-screen page that shows the Dolphin setup steps (used when user taps for details).
+class TutorialDetailScreen extends StatelessWidget {
+  const TutorialDetailScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Step-by-step instructions'),
+      ),
+      body: SingleChildScrollView(
+        child: const TutorialStepsContent(),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/tutorial/tutorial_page_content.dart
+++ b/lib/ui/screens/tutorial/tutorial_page_content.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial/tutorial_slide.dart';
+
+/// Tutorial content for a single page. [isActive] drives enter animation.
+class TutorialPageContent extends StatelessWidget {
+  final bool isActive;
+  final TutorialSlide slide;
+
+  const TutorialPageContent({
+    super.key,
+    required this.isActive,
+    required this.slide,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      opacity: isActive ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 280),
+      child: AnimatedSlide(
+        offset: isActive ? Offset.zero : const Offset(0, 0.08),
+        duration: const Duration(milliseconds: 280),
+        curve: Curves.easeOutCubic,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 28.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(slide.icon, size: 72, color: Theme.of(context).primaryColor),
+              const SizedBox(height: 24),
+              Text(
+                slide.title,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                slide.body,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Colors.grey[700],
+                      height: 1.4,
+                    ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/tutorial/tutorial_slide.dart
+++ b/lib/ui/screens/tutorial/tutorial_slide.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+/// Data for a single tutorial screen/slide.
+class TutorialSlide {
+  final IconData icon;
+  final String title;
+  final String body;
+
+  /// When true, this slide uses [TutorialConfigurePageContent] (Configure Dolphin + tap for details).
+  final bool isConfigurePage;
+
+  const TutorialSlide({
+    required this.icon,
+    required this.title,
+    required this.body,
+    this.isConfigurePage = false,
+  });
+}

--- a/lib/ui/screens/tutorial/tutorial_steps_content.dart
+++ b/lib/ui/screens/tutorial/tutorial_steps_content.dart
@@ -1,0 +1,210 @@
+import 'package:flutter/material.dart';
+import 'package:network_info_plus/network_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class TutorialStep extends StatelessWidget {
+  final int number;
+  final String text;
+  final TextStyle style;
+
+  const TutorialStep({
+    super.key,
+    required this.number,
+    required this.text,
+    required this.style,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 24,
+            child: Text(
+              '$number.',
+              style: style.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ),
+          Expanded(child: Text(text, style: style)),
+        ],
+      ),
+    );
+  }
+}
+
+class TutorialPhoneIpStep extends StatelessWidget {
+  final TextStyle bodyStyle;
+
+  const TutorialPhoneIpStep({super.key, required this.bodyStyle});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 12.0, bottom: 10.0),
+      child: FutureBuilder<String?>(
+        future: NetworkInfo().getWifiIP(),
+        builder: (context, snapshot) {
+          if (snapshot.hasData && snapshot.data != null) {
+            return Text(
+              'Your IP: ${snapshot.data}',
+              style: bodyStyle.copyWith(fontWeight: FontWeight.w600),
+            );
+          }
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return Row(
+              children: [
+                SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                const SizedBox(width: 8),
+                Text('Getting your IP…', style: bodyStyle),
+              ],
+            );
+          }
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+}
+
+class TutorialLinkText extends StatelessWidget {
+  final String text;
+  final String url;
+  final TextStyle style;
+
+  const TutorialLinkText({
+    super.key,
+    required this.text,
+    required this.url,
+    required this.style,
+  });
+
+  Future<void> _openUrl() async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: _openUrl,
+      child: Text(text, style: style),
+    );
+  }
+}
+
+/// Repository URL: setup guide and WiiMoteDSU.ini profile download.
+const String tutorialRepoUrl = 'https://github.com/marcowindt/WiiMoteDSU';
+
+class TutorialStepsContent extends StatelessWidget {
+  const TutorialStepsContent({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bodyStyle =
+        theme.textTheme.bodyMedium?.copyWith(
+          color: Colors.grey[700],
+          height: 1.4,
+        ) ??
+        const TextStyle();
+    final boldStyle = bodyStyle.copyWith(fontWeight: FontWeight.w600);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: 8),
+          Text(
+            'Dolphin setup steps',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.titleLarge?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TutorialStep(
+                number: 1,
+                text: 'Open Controller Settings.',
+                style: bodyStyle,
+              ),
+              TutorialStep(
+                number: 2,
+                text: 'Click Alternate Input Sources.',
+                style: bodyStyle,
+              ),
+              TutorialStep(number: 3, text: 'Check Enable.', style: bodyStyle),
+              TutorialStep(number: 4, text: 'Click Add.', style: bodyStyle),
+              TutorialStep(
+                number: 5,
+                text:
+                    'Enter your phone\'s IP address, port number 26760, and give it a description.',
+                style: bodyStyle,
+              ),
+              TutorialPhoneIpStep(bodyStyle: bodyStyle),
+              TutorialStep(
+                number: 6,
+                text:
+                    'Select Emulated Wii Remote for Wii Remote 1, then Configure.',
+                style: bodyStyle,
+              ),
+              TutorialStep(
+                number: 7,
+                text:
+                    'With this app open, select "DSUClient/0/[your_description]" (your phone) as the input device.',
+                style: bodyStyle,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '8. Map the buttons in Dolphin, or download the controller profile:',
+                style: boldStyle,
+              ),
+              const SizedBox(height: 6),
+              Padding(
+                padding: const EdgeInsets.only(left: 12.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '• Map buttons manually in Dolphin\'s controller config, or',
+                      style: bodyStyle,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '• Download the WiiMoteDSU.ini profile from the repository:',
+                      style: bodyStyle,
+                    ),
+                    const SizedBox(height: 6),
+                    TutorialLinkText(
+                      text:
+                          'Open repository (setup guide and profile download)',
+                      url: tutorialRepoUrl,
+                      style: bodyStyle.copyWith(
+                        color: theme.primaryColor,
+                        decoration: TextDecoration.underline,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/screens/tutorial_screen.dart
+++ b/lib/ui/screens/tutorial_screen.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial/tutorial_configure_page_content.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial/tutorial_detail_screen.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial/tutorial_page_content.dart';
+import 'package:wiimote_dsu/ui/screens/tutorial/tutorial_slide.dart';
+
+class TutorialScreen extends StatefulWidget {
+  final void Function(BuildContext context) onComplete;
+
+  const TutorialScreen({Key? key, required this.onComplete}) : super(key: key);
+
+  @override
+  State<TutorialScreen> createState() => _TutorialScreenState();
+}
+
+class _TutorialScreenState extends State<TutorialScreen> {
+  static const _slides = <TutorialSlide>[
+    TutorialSlide(
+      icon: Icons.wifi,
+      title: 'Dolphin on your network',
+      body: 'This app works with the Dolphin emulator running on another device on the same Wi-Fi. It sends controller input over the network.',
+    ),
+    TutorialSlide(
+      icon: Icons.info_outline,
+      title: 'Not for a real Wii',
+      body: 'Designed for Dolphin only—not for an actual Wii console.',
+    ),
+    TutorialSlide(
+      icon: Icons.settings,
+      title: 'Configure Dolphin',
+      body: 'In Dolphin: Controller Settings → Alternate Input Sources. Use your phone\'s IP and port 26760.',
+      isConfigurePage: true,
+    ),
+  ];
+
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  void _pushDetailScreen(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (context) => const TutorialDetailScreen()),
+    );
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController.addListener(() {
+      final page = _pageController.page?.round() ?? 0;
+      if (page != _currentPage) setState(() => _currentPage = page);
+    });
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _onComplete() => widget.onComplete(context);
+
+  void _onNext() {
+    if (_currentPage >= _slides.length - 1) {
+      _onComplete();
+    } else {
+      _pageController.nextPage(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isLastPage = _currentPage == _slides.length - 1;
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: _onComplete,
+                child: const Text('Skip'),
+              ),
+            ),
+            Expanded(
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: _slides.length,
+                itemBuilder: (context, index) {
+                  final slide = _slides[index];
+                  if (slide.isConfigurePage) {
+                    return TutorialConfigurePageContent(
+                      isActive: index == _currentPage,
+                      onShowDetails: () => _pushDetailScreen(context),
+                      slide: slide,
+                    );
+                  }
+                  return TutorialPageContent(
+                    isActive: index == _currentPage,
+                    slide: slide,
+                  );
+                },
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(
+                _slides.length,
+                (i) => AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  margin: const EdgeInsets.symmetric(horizontal: 4),
+                  width: _currentPage == i ? 24 : 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: _currentPage == i
+                        ? Theme.of(context).primaryColor
+                        : Colors.grey[300],
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0),
+              child: SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _onNext,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: Text(isLastPage ? 'Get started' : 'Next'),
+                ),
+              ),
+            ),
+            const SizedBox(height: 32),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -501,6 +501,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_math:
     dependency: transitive
     description:
@@ -575,4 +639,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.8 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   provider: ^6.1.5+1
   shared_preferences: ^2.2.2
   network_info_plus: ^6.0.0
+  url_launcher: ^6.2.5
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Since app store reviews and some github issues have been created by people because they don't understand how the app works, a tutorial screen is added on first launch and can be re-opened via settings screen.

<img width="250" alt="Tutorial page 1" src="https://github.com/user-attachments/assets/2cfb6aee-910b-4bbe-b52a-b92fc53e9d9a" />
<img width="250" alt="Tutorial page 2" src="https://github.com/user-attachments/assets/fe248868-a709-4c42-b161-36bff4377af8" />
<img width="250" alt="Tutorial page 3" src="https://github.com/user-attachments/assets/de1c859f-1f43-400b-b9f6-17243ae26707" />
<img width="250" alt="Tutorial page 3 more detailed insctructions" src="https://github.com/user-attachments/assets/200a8842-3515-4690-b106-5c281ad8eac7" />
<img width="250" alt="Settings screen" src="https://github.com/user-attachments/assets/10ba84be-1333-4d1d-8fd2-ff4d9fb011ba" />




